### PR TITLE
Parse optics traversals

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -42,6 +42,7 @@ tests:
     - base
     - tasty
     - tasty-hunit
+    - tasty-hspec
     - text-transforms
     build-tools:
       - tasty-discover

--- a/src/LazyParseTransforms.hs
+++ b/src/LazyParseTransforms.hs
@@ -26,7 +26,7 @@ withPrism' p cont = withPrism p $ \build match ->
 focusing :: Lens' s Text -> Lens' (s, Context) (Text, Context)
 focusing focus = alongside (focus . emptyContext) id . _1
 
-manyOf :: Pprism Text a -> Pprism Text Text -> Ptraversal Text a
+manyOf :: Pprism Text a -> Ptraversal Text Text -> Ptraversal Text a
 manyOf single negative =
   many' (andThen single negative) . mergeContext
     where

--- a/src/LazyParseTransforms.hs
+++ b/src/LazyParseTransforms.hs
@@ -17,21 +17,14 @@ type P p f a b = Optic' p f (a, Context) (b, Context)
 type Pprism a b = forall p f. (Choice p, Applicative f) => P p f a b
 type Ptraversal a b = forall f. (Applicative f) => P (->) f a b
 
-withPrism' :: Prism' s a -> ((a -> s) -> (s -> Maybe a) -> r) -> r
-withPrism' p cont = withPrism p $ \build match ->
-    let match' s = case match s of
-          Right x -> Just x
-          Left _ -> Nothing
-    in cont build match'
-
 focusing :: Lens' s Text -> Lens' (s, Context) (Text, Context)
-focusing focus = alongside (focus . emptyContext) id . _1
+focusing focus = alongside (focus . text) id . _1
 
-emptyContext :: Iso' Text (Text, Context)
-emptyContext = iso (\txt -> (txt, Context "")) (\(txt, Context rest) -> txt <> rest)
+text :: Iso' Text (Text, Context)
+text = iso (\txt -> (txt, Context "")) (\(txt, Context rest) -> txt <> rest)
 
 some' :: Ptraversal Text a -> Ptraversal Text a
-some' p = andThen p (many' p) . alongside chosen id
+some' p = (p ||> many' p) . alongside chosen id
 
 many' :: Ptraversal Text a -> Ptraversal Text a
 many' p = failing (some' p) ignored
@@ -44,48 +37,25 @@ choice' [] = ignored
 
 newtype ChoicePrism a b = ChoicePrism { unChoicePrism :: Pprism a b }
 
--- ChoicePrism newtype for impredicative polymorphism workaround
--- Int to track which Prism succeeded, to pick the correct builder
-choice :: [ ChoicePrism a b ] -> Pprism a (b, Int)
-choice ps = unChoicePrism $ go 0 ps
-  where
-    go n (p:[]) = ChoicePrism $ unChoicePrism p . swapped . mapping (index n) . swapped
-    go n (p:rest) = ChoicePrism $ (unChoicePrism p <||> unChoicePrism (go (n+1) rest)) . swapped . mapping (marshal n) . swapped
-    go _ [] = error "empty choice"
+-- unlike `ignored` supports different types
+-- problem: double running of afbst
+(<||>) :: Ptraversal a x -> Ptraversal a y -> Ptraversal a (Either x y)
+(<||>) afbst afbst' afb'' s =
+  case preview afbst s of
+    Just _ -> afbst afb s
+    Nothing -> afbst' afb' s
+  where afb  (a,ctx) = onlyIfLeft a ctx <$> afb'' (Left a, ctx)
+        afb' (a,ctx) = onlyIfRight a ctx <$> afb'' (Right a, ctx)
 
-    index :: Int -> Iso' a (a,Int)
-    index n = iso (\a -> (a,n)) (\(a,n) -> a)
+        onlyIfRight _ _ (Right b, ctx') = (b, ctx')
+        onlyIfRight a ctx (Left _, _) = (a, ctx)
 
-    marshal :: Int -> Iso' (Either b (b, Int)) (b, Int)
-    marshal n = iso merge split
-      where
-        merge (Left b) = (b, n)
-        merge (Right (b, k)) = (b, k)
-
-        split (b, k) | k > 0  = Right (b, k)
-        split (b, k) | k == 0 = Left b
-
--- cannot use Control.Lens.Traversal.failing because it composes Prisms into Traversals
--- and we need it to stay a Prism because `andThen` takes Prisms
--- it returns Either because we need to build according to the correct Prism
-(<||>) :: Pprism a x -> Pprism a y -> Pprism a (Either x y)
-(<||>) first second = withPrism' first $ \b m ->
-  withPrism' second $ \b' m' ->
-  let
-    match (a, ctx) =  case m (a, ctx) of
-      Just (x,ctx) -> Just (Left x, ctx)
-      Nothing -> case m' (a, ctx) of
-        Just (y, ctx) -> Just (Right y, ctx)
-        Nothing -> Nothing
-
-    build (Left x, ctx) = b (x, ctx)
-    build (Right y, ctx) = b' (y, ctx)
-   in prism' build match
-
+        onlyIfLeft _ _ (Left b, ctx') = (b, ctx')
+        onlyIfLeft a ctx (Right _, _) = (a, ctx)
 
 -- problem: double running of afbst
-andThen :: Ptraversal a x -> Ptraversal Text y -> Ptraversal a (Either x y)
-andThen afbsft afbsft' afb'' s =
+(||>) :: Ptraversal a x -> Ptraversal Text y -> Ptraversal a (Either x y)
+(||>) afbsft afbsft' afb'' s =
   case lastOf afbsft s of
    Just (_, Context unconsumed) ->
      let merge (a, Context rebuilt) (txt, Context ctx) = (a, Context (fromMaybe (error "unconsumed was consumed") (stripSuffix unconsumed rebuilt) <> txt <> ctx))

--- a/src/LazyParseTransforms.hs
+++ b/src/LazyParseTransforms.hs
@@ -35,8 +35,6 @@ choice' :: [ChoiceTraversal a b] -> Ptraversal a b
 choice' (ChoiceTraversal p:ps) = failing p (choice' ps)
 choice' [] = ignored
 
-newtype ChoicePrism a b = ChoicePrism { unChoicePrism :: Pprism a b }
-
 -- unlike `ignored` supports different types
 -- problem: double running of afbst
 (<||>) :: Ptraversal a x -> Ptraversal a y -> Ptraversal a (Either x y)

--- a/src/LazyParseTransforms.hs
+++ b/src/LazyParseTransforms.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module LazyParseTransforms where
+
+import Data.Text as T
+
+import Text.Parsec hiding (choice)
+import Control.Lens (Lens', Traversal', Iso', Choice, Optic', alongside, Prism', prism, prism', withPrism, iso, swapped, mapping, _Left, failing, ignored, _1)
+import Control.Applicative
+
+type Parser a = Parsec Text () a
+newtype Context = Context Text deriving Show
+type P p f a b = Optic' p f (a, Context) (b, Context)
+type Pprism a b = forall p f. (Choice p, Applicative f) => P p f a b
+type Ptraversal a b = forall f. (Applicative f) => P (->) f a b
+
+withPrism' :: Prism' s a -> ((a -> s) -> (s -> Maybe a) -> r) -> r
+withPrism' p cont = withPrism p $ \build match ->
+    let match' s = case match s of
+          Right x -> Just x
+          Left _ -> Nothing
+    in cont build match'
+
+focusing :: Lens' s Text -> Lens' (s, Context) (Text, Context)
+focusing focus = alongside (focus . emptyContext) id . _1
+
+manyOf :: Pprism Text a -> Pprism Text Text -> Ptraversal Text a
+manyOf single negative =
+  many' (andThen single negative) . mergeContext
+    where
+      mergeContext :: Iso' ((a,Text), Context) (a, Context)
+      mergeContext = iso (\((x,negative), Context ctx) -> (x, Context (negative <> ctx))) (\(x, ctx) -> ((x,""), ctx))
+
+emptyContext :: Iso' Text (Text, Context)
+emptyContext = iso (\txt -> (txt, Context "")) (\(txt, Context rest) -> txt <> rest)
+
+some' :: Pprism Text a -> Ptraversal Text a
+some' p = andThen' p (many' p)
+
+many' :: Pprism Text a -> Ptraversal Text a
+many' p = failing (some' p) ignored
+
+newtype ChoicePrism a b = ChoicePrism { unChoicePrism :: Pprism a b }
+
+-- ChoicePrism newtype for impredicative polymorphism workaround
+-- Int to track which Prism succeeded, to pick the correct builder
+choice :: [ ChoicePrism a b ] -> Pprism a (b, Int)
+choice ps = unChoicePrism $ go 0 ps
+  where
+    go n (p:[]) = ChoicePrism $ unChoicePrism p . swapped . mapping (index n) . swapped
+    go n (p:rest) = ChoicePrism $ (unChoicePrism p <||> unChoicePrism (go (n+1) rest)) . swapped . mapping (marshal n) . swapped
+    go _ [] = error "empty choice"
+
+    index :: Int -> Iso' a (a,Int)
+    index n = iso (\a -> (a,n)) (\(a,n) -> a)
+
+    marshal :: Int -> Iso' (Either b (b, Int)) (b, Int)
+    marshal n = iso merge split
+      where
+        merge (Left b) = (b, n)
+        merge (Right (b, k)) = (b, k)
+
+        split (b, k) | k > 0  = Right (b, k)
+        split (b, k) | k == 0 = Left b
+
+-- cannot use Control.Lens.Traversal.failing because it composes Prisms into Traversals
+-- and we need it to stay a Prism because `andThen` takes Prisms
+-- it returns Either because we need to build according to the correct Prism
+(<||>) :: Pprism a x -> Pprism a y -> Pprism a (Either x y)
+(<||>) first second = withPrism' first $ \b m ->
+  withPrism' second $ \b' m' ->
+  let
+    match (a, ctx) =  case m (a, ctx) of
+      Just (x,ctx) -> Just (Left x, ctx)
+      Nothing -> case m' (a, ctx) of
+        Just (y, ctx) -> Just (Right y, ctx)
+        Nothing -> Nothing
+
+    build (Left x, ctx) = b (x, ctx)
+    build (Right y, ctx) = b' (y, ctx)
+   in prism' build match
+
+-- how can second fail?
+-- afb never gets invoked, t is just s
+andThen' :: Pprism Text x -> Ptraversal Text x -> Ptraversal Text x
+andThen' first afbsft =
+  let afbsft' afb s = withPrism' first $ \build match ->
+                case match s of
+                  Nothing -> pure s
+                  Just (a, Context unconsumed) ->
+                    let fb = afb (a, Context "")
+                        ft = afbsft afb (unconsumed, Context "")
+                        buildFirstBefore (b, Context ctx) (s, Context ctx') = build (b, Context (ctx <> s <> ctx'))
+                    in buildFirstBefore <$> fb <*> ft
+  in afbsft'
+
+andThen :: Pprism a x -> Pprism Text y -> Pprism a (x, y)
+andThen first second = withPrism' first $ \b m ->
+  let
+    match (a, ctx) = case m (a, ctx) of
+      Just (x, (Context unconsumed)) -> withPrism' second $ \b' m' ->
+        case m' (unconsumed, (Context "")) of
+          Just (y, unconsumed') -> Just ((x,y), unconsumed')
+          Nothing -> Nothing
+      Nothing -> Nothing
+
+    build ((x,y), ctx) = withPrism' second $ \b' m' ->
+      case b' (y, ctx) of
+         (t, Context ctx') -> b (x, (Context (t <> ctx')))
+   in prism' build match
+
+parseInContext :: Parser a -> (Text, Context) -> Maybe (a, Context)
+parseInContext p (input, (Context after)) = eitherToMaybe $
+  parse (contextualise <$> p <*> getInput) "" input
+  where
+    contextualise parsed unconsumed = (parsed, Context (unconsumed <> after))
+    eitherToMaybe e = case e of
+            Left _ -> Nothing
+            Right x -> Just x

--- a/src/LazyParseTransforms.hs
+++ b/src/LazyParseTransforms.hs
@@ -59,7 +59,11 @@ choice' [] = ignored
   in case getLast (getConst constt) of
        Just (_, Context unconsumed) ->
          let ft' = afbsft' afb' (unconsumed, Context "")
-             merge (a, Context rebuilt) (txt, Context ctx) = (a, Context (fromMaybe (error "unconsumed was consumed") (stripSuffix unconsumed rebuilt) <> txt <> ctx))
+             merge (a, Context rebuilt) (txt, Context ctx) = (a, Context (actuallyConsumed rebuilt <> txt <> ctx))
+             actuallyConsumed rebuilt | rebuilt == "" = unconsumed
+             actuallyConsumed rebuilt | otherwise =
+               fromMaybe (error . unpack $ "unconsumed was consumed: \"" <> unconsumed <> "\" / \"" <> rebuilt <> "\"") $
+                 (stripSuffix unconsumed rebuilt)
          in merge <$> ft <*> ft'
        Nothing -> pure s
 

--- a/src/MarkdownLazy.hs
+++ b/src/MarkdownLazy.hs
@@ -40,6 +40,26 @@ h n = prism' build match
 
     hashes k = Prelude.take k (repeat '#')
 
+headers :: Ptraversal Text Header
+headers = choice' [
+    ChoiceTraversal (h 1)
+  , ChoiceTraversal (h 2)
+  , ChoiceTraversal (h 3)
+  , ChoiceTraversal (h 4)
+  , ChoiceTraversal (h 5)
+  , ChoiceTraversal (h 6)
+  ]
+
+headersPrism :: Pprism Text (Header, Int)
+headersPrism = choice [
+    ChoicePrism (h 1)
+  , ChoicePrism (h 2)
+  , ChoicePrism (h 3)
+  , ChoicePrism (h 4)
+  , ChoicePrism (h 5)
+  , ChoicePrism (h 6)
+  ]
+
 
 notheader :: Pprism Text Text
 notheader = prism' build match

--- a/src/MarkdownLazy.hs
+++ b/src/MarkdownLazy.hs
@@ -3,131 +3,16 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
+module MarkdownLazy where
+
 import MarkdownParse (withinMany)
 
+import LazyParseTransforms
+
 import Data.Text as T
-
 import Text.Parsec hiding (choice)
-import Control.Lens (Lens', Traversal', Iso', Choice, Optic', alongside, Prism', prism, prism', withPrism, iso, swapped, mapping, _Left, failing, ignored, _1)
+import Control.Lens (prism')
 import Control.Lens.TH
-import Control.Applicative hiding (many, some)
-
-type Parser a = Parsec Text () a
-newtype Context = Context Text deriving Show
-type P p f a b = Optic' p f (a, Context) (b, Context)
-type Pprism a b = forall p f. (Choice p, Applicative f) => P p f a b
-type Ptraversal a b = forall f. (Applicative f) => P (->) f a b
-
-withPrism' :: Prism' s a -> ((a -> s) -> (s -> Maybe a) -> r) -> r
-withPrism' p cont = withPrism p $ \build match ->
-    let match' s = case match s of
-          Right x -> Just x
-          Left _ -> Nothing
-    in cont build match'
-
-focusing :: Lens' s Text -> Lens' (s, Context) (Text, Context)
-focusing focus = alongside (focus . emptyContext) id . _1
-
-manyOf :: Pprism Text a -> Pprism Text Text -> Ptraversal Text a
-manyOf single negative =
-  many' (andThen single negative) . mergeContext
-    where
-      mergeContext :: Iso' ((a,Text), Context) (a, Context)
-      mergeContext = iso (\((x,negative), Context ctx) -> (x, Context (negative <> ctx))) (\(x, ctx) -> ((x,""), ctx))
-
-emptyContext :: Iso' Text (Text, Context)
-emptyContext = iso (\txt -> (txt, Context "")) (\(txt, Context rest) -> txt <> rest)
-
-some :: Pprism Text a -> Ptraversal Text a
-some p = andThen' p (many' p)
-
-many' :: Pprism Text a -> Ptraversal Text a
-many' p = failing (some p) ignored
-
-newtype ChoicePrism a b = ChoicePrism { unChoicePrism :: Pprism a b }
-
--- ChoicePrism newtype for impredicative polymorphism workaround
--- Int to track which Prism succeeded, to pick the correct builder
-choice :: [ ChoicePrism a b ] -> Pprism a (b, Int)
-choice ps = unChoicePrism $ go 0 ps
-  where
-    go n (p:[]) = ChoicePrism $ unChoicePrism p . swapped . mapping (index n) . swapped
-    go n (p:rest) = ChoicePrism $ (unChoicePrism p <||> unChoicePrism (go (n+1) rest)) . swapped . mapping (marshal n) . swapped
-    go _ [] = error "empty choice"
-
-    index :: Int -> Iso' a (a,Int)
-    index n = iso (\a -> (a,n)) (\(a,n) -> a)
-
-    marshal :: Int -> Iso' (Either b (b, Int)) (b, Int)
-    marshal n = iso merge split
-      where
-        merge (Left b) = (b, n)
-        merge (Right (b, k)) = (b, k)
-
-        split (b, k) | k > 0  = Right (b, k)
-        split (b, k) | k == 0 = Left b
-
-headers :: Pprism Text (Header, Int)
-headers = choice [
-   ChoicePrism (h 1),
-   ChoicePrism (h 2),
-   ChoicePrism (h 3),
-   ChoicePrism (h 4),
-   ChoicePrism (h 5),
-   ChoicePrism (h 6)
- ]
-
--- cannot use Control.Lens.Traversal.failing because it composes Prisms into Traversals
--- and we need it to stay a Prism because `andThen` takes Prisms
--- it returns Either because we need to build according to the correct Prism
-(<||>) :: Pprism a x -> Pprism a y -> Pprism a (Either x y)
-(<||>) first second = withPrism' first $ \b m ->
-  withPrism' second $ \b' m' ->
-  let
-    match (a, ctx) =  case m (a, ctx) of
-      Just (x,ctx) -> Just (Left x, ctx)
-      Nothing -> case m' (a, ctx) of
-        Just (y, ctx) -> Just (Right y, ctx)
-        Nothing -> Nothing
-
-    build (Left x, ctx) = b (x, ctx)
-    build (Right y, ctx) = b' (y, ctx)
-   in prism' build match
-
--- how can second fail?
--- afb never gets invoked, t is just s
-andThen' :: Pprism Text x -> Ptraversal Text x -> Ptraversal Text x
-andThen' first afbsft =
-  let afbsft' afb s = withPrism' first $ \build match ->
-                case match s of
-                  Nothing -> pure s
-                  Just (a, Context unconsumed) ->
-                    let fb = afb (a, Context "")
-                        ft = afbsft afb (unconsumed, Context "")
-                        buildFirstBefore (b, Context ctx) (s, Context ctx') = build (b, Context (ctx <> s <> ctx'))
-                    in buildFirstBefore <$> fb <*> ft
-  in afbsft'
-
-andThen :: Pprism a x -> Pprism Text y -> Pprism a (x, y)
-andThen first second = withPrism' first $ \b m ->
-  let
-    match (a, ctx) = case m (a, ctx) of
-      Just (x, (Context unconsumed)) -> withPrism' second $ \b' m' ->
-        case m' (unconsumed, (Context "")) of
-          Just (y, unconsumed') -> Just ((x,y), unconsumed')
-          Nothing -> Nothing
-      Nothing -> Nothing
-
-    build ((x,y), ctx) = withPrism' second $ \b' m' ->
-      case b' (y, ctx) of
-         (t, Context ctx') -> b (x, (Context (t <> ctx')))
-   in prism' build match
-
-parseInContext :: Parser a -> (Text, Context) -> Maybe (a, Context)
-parseInContext p (input, (Context after)) = eitherToMaybe $
-  parse (liftA2 (\parsed unconsumed ->
-    (parsed, Context (unconsumed <> after)))
-    p getInput) "" input
 
 newtype Italic = Italic { _unItalic :: Text } deriving Show
 data Header = Header {

--- a/src/MarkdownLazy.hs
+++ b/src/MarkdownLazy.hs
@@ -50,17 +50,6 @@ headers = choice' [
   , ChoiceTraversal (h 6)
   ]
 
-headersPrism :: Pprism Text (Header, Int)
-headersPrism = choice [
-    ChoicePrism (h 1)
-  , ChoicePrism (h 2)
-  , ChoicePrism (h 3)
-  , ChoicePrism (h 4)
-  , ChoicePrism (h 5)
-  , ChoicePrism (h 6)
-  ]
-
-
 notheader :: Pprism Text Text
 notheader = prism' build match
   where

--- a/src/MarkdownLazy.hs
+++ b/src/MarkdownLazy.hs
@@ -29,7 +29,7 @@ i = prism' build match
 noti :: Pprism Text Text
 noti = prism' build match
   where
-    match = parseInContext $ pack <$> many (noneOf (['*']))
+    match = parseInContext $ pack <$> many1 (noneOf (['*']))
     build (txt, Context after) = (txt, Context after)
 
 h :: Int ->  Pprism Text Header
@@ -38,7 +38,7 @@ h n = prism' build match
     match = parseInContext $ Header n . pack <$> between (string (hashes n) *> char ' ') endOfLine (many1 (noneOf ['\n']))
     build (Header k txt, Context after) = (pack (hashes k) <> " " <> txt <> "\n" , Context after)
 
-    hashes k = Prelude.take k (repeat '#')
+    hashes k = Prelude.take k (Prelude.repeat '#')
 
 headers :: Ptraversal Text Header
 headers = choice' [
@@ -53,12 +53,11 @@ headers = choice' [
 notheader :: Pprism Text Text
 notheader = prism' build match
   where
-    match = parseInContext $ pack <$> many (noneOf (['#']))
+    match = parseInContext $ pack <$> many1 (noneOf (['#']))
     build (txt, Context after) = (txt, Context after)
 
-eitherToMaybe e = case e of
-        Left _ -> Nothing
-        Right x -> Just x
+allTheHeaders :: Ptraversal Text (Either Header Text)
+allTheHeaders = many' (headers <||> notheader)
 
 makeLenses ''Italic
 makeLenses ''Header

--- a/tests/MarkdownLazyTest.hs
+++ b/tests/MarkdownLazyTest.hs
@@ -31,12 +31,7 @@ spec_markdown_lazy = do
        "# *i* not i\n not h" `shouldBe`
        "# *x* not i\n not h"
 
-   it "focusing inside many" $ do
-     flip set "x" (text . many' (h 1 . focusing content . i) . _1 . unItalic)
-       "# *i* not i\n# *i2* not i2\n# no i\n *i* not i" `shouldBe`
-       "# *x* not i\n# *x* not i2\n# no i\n *i* not i"
-
-   it "focusing outside many" $ do
+   it "focusing after many" $ do
      flip set "x" (text . many' (h 1) . focusing content . i . _1 . unItalic)
        "# *i* not i\n# *i2* not i2\n# no i\n *i* not i" `shouldBe`
        "# *x* not i\n# *x* not i2\n# no i\n *i* not i"

--- a/tests/MarkdownLazyTest.hs
+++ b/tests/MarkdownLazyTest.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE OverloadedStrings #-}
+module MarkdownLazyTest where
+
+import Test.Tasty
+import Test.Tasty.Hspec
+
+import MarkdownLazy
+import LazyParseTransforms
+import Control.Lens
+
+spec_markdown_lazy :: Spec
+spec_markdown_lazy = do
+ describe "markdown lazy" $ do
+   it "italic" $
+     flip set "x" (text . i . _1 . unItalic)
+       "*i*" `shouldBe`
+       "*x*"
+
+   it "many" $ do
+     flip set "x" (text . many' i . _1 . unItalic)
+       "*i**i2*" `shouldBe`
+       "*x**x*"
+
+   it "indexing into many" $ do
+     flip set "x" (text . partsOf (many' i . _1) . ix 1 . unItalic)
+       "*i**i2**i3*" `shouldBe`
+       "*i**x**i3*"
+
+   it "focusing" $ do
+     flip set "x" (text . h 1 . focusing content . i . _1 . unItalic)
+       "# *i* not i\n not h" `shouldBe`
+       "# *x* not i\n not h"
+
+   it "focusing inside many" $ do
+     flip set "x" (text . many' (h 1 . focusing content . i) . _1 . unItalic)
+       "# *i* not i\n# *i2* not i2\n# no i\n *i* not i" `shouldBe`
+       "# *x* not i\n# *x* not i2\n# no i\n *i* not i"
+
+   it "focusing outside many" $ do
+     flip set "x" (text . many' (h 1) . focusing content . i . _1 . unItalic)
+       "# *i* not i\n# *i2* not i2\n# no i\n *i* not i" `shouldBe`
+       "# *x* not i\n# *x* not i2\n# no i\n *i* not i"
+
+   it "fail <||> succeed" $ do
+     flip set "x" (text . (h 1 <||> i) . _1 . _Right . unItalic)
+       "*i*# h1\n" `shouldBe` "*x*# h1\n"
+
+   it "succeed <||> fail" $ do
+     flip set "x" (text . (h 1 <||> i) . _1 . _Left . content)
+       "# h1\n*i*" `shouldBe` "# x\n*i*"
+
+   it "<||> inside many: left succeeds" $ do
+     flip set "x" (text . many' (i <||> h 1) . _1 . _Left . unItalic)
+       "*i*# h1\n" `shouldBe` "*x*# h1\n"
+
+   it "<||> inside many: right succeeds" $ do
+     flip set "x" (text . many' (i <||> h 1) . _1 . _Right . content)
+       "*i*# h1\n" `shouldBe` "*i*# x\n"

--- a/unindent-headers-bullets/Main.hs
+++ b/unindent-headers-bullets/Main.hs
@@ -1,27 +1,19 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
-import MarkdownParse (everything)
-import qualified Markdown
-import Anki
-
-import Text.Parsec
-import Lucid
+import MarkdownLazy
+import LazyParseTransforms
+import Control.Lens
 
 import qualified Data.Text as T
-import qualified Data.Text.Lazy.IO as LTIO
+import qualified Data.Text.IO as TIO
 import qualified Control.Foldl as F
 
 import Turtle as T (stdin, lineToText, inproc, die, empty, fold)
 
 getText = T.fold stdin (F.foldMap (\l -> lineToText l <> "\n") id)
 
+unindentHeaders = flip over (\level -> max (level-1) 1)  (text . allTheHeaders . _1 . _Left . level)
+
 main :: IO ()
-main = do
-  source <- getText
-  case parse everything "" source of
-    Left err -> die (T.pack (show err))
-    Right parsed -> do
-      putStrLn . show . Markdown.unindentAll $ parsed
-
-
+main = TIO.putStr . unindentHeaders =<< getText


### PR DESCRIPTION
now that everything is `Traversal` combinators can compose arbitrarily

- [x] problem: double traversals for `(||>)` and `(<||>)`

```haskell
λ toListOf (text . many' ((h 2 . focusing content . i) <||> i)) "*i**i2*## *italic in h2* not italic\n"
[
    ( Right
        ( Italic
            { _unItalic = "i" }
        )
    , Context "*i2*## *italic in h2* not italic
      "
    )
,
    ( Right
        ( Italic
            { _unItalic = "i2" }
        )
    , Context "## *italic in h2* not italic
      "
    )
,
    ( Left
        ( Italic
            { _unItalic = "italic in h2" }
        )
    , Context " not italic"
    )
]
```
