### PR TITLE
`focusing` inside `||>`

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -30,6 +30,7 @@ dependencies:
 - lucid
 - parsec
 - foldl
+- vector
 
 library:
   source-dirs: src

--- a/src/LazyParseTransforms.hs
+++ b/src/LazyParseTransforms.hs
@@ -69,10 +69,8 @@ andThen rightMustSucceed afbsft afbsft' afb'' s@(_, Context _ above youAreHere) 
              Pair constt' ft' = afbsft' aConstfb' (unconsumed, Context "" above youAreHere)
          in case getConst constt' of
            Any True ->
-             let merge (a, Context rebuilt parent lvl_left) (txt, Context ctx parent' lvl_right) =
-                   (a, Context (actuallyConsumed rebuilt <> txt <> ctx)
-                               (if (lvl_left > lvl_right) then parent else parent')
-                               (max lvl_left lvl_right))
+             let merge (a, Context rebuilt _ _) (txt, Context ctx _ _) =
+                   (a, Context (actuallyConsumed rebuilt <> txt <> ctx) above youAreHere)
                  actuallyConsumed rebuilt | rebuilt == "" = unconsumed
                  actuallyConsumed rebuilt | otherwise =
                    fromMaybe (error . unpack $ "unconsumed was consumed: \"" <> unconsumed <> "\" / \"" <> rebuilt <> "\"") $

--- a/src/LazyParseTransforms.hs
+++ b/src/LazyParseTransforms.hs
@@ -64,6 +64,11 @@ choice' [] = ignored
 
 -- "horizontal" left-to-right composition:
 -- does not change level, just current-level unconsumed
+-- first crux is passing on remaining unconsumed after left has succeeded
+-- second crux is left may be focused,
+--   in which case we need to retrieve its parent unconsumed
+-- third crux is after left context has been rebuilt,
+--   we need to trim it because unconsumed should now be to the after right, not left
 andThen :: Bool -> Ptraversal a x -> Ptraversal Text y -> Ptraversal a (Either x y)
 andThen rightMustSucceed afbsft afbsft' afb'' s@(_, Context _ above lvl) =
   let Pair constt ft = afbsft aConstfb s

--- a/src/LazyParseTransforms.hs
+++ b/src/LazyParseTransforms.hs
@@ -14,26 +14,25 @@ import Control.Applicative
 
 type Parser a = Parsec Text () a
 -- first is unconsumed
--- second is top-level after `focusing`
--- which we need to preserve for ||> to know what is unconsumed at top-level
--- multiple rounds of focusing should preserve the top-level
-data Context = Context Text (Maybe Text) deriving Show
+-- second is list of unconsumeds after successive `focusing`
+-- which we need to preserve for ||> to know what is unconsumed at the level it is applied
+data Context = Context Text [Text] Int deriving Show
 type P p f a b = Optic' p f (a, Context) (b, Context)
 type Pprism a b = forall p f. (Choice p, Applicative f) => P p f a b
 type Ptraversal a b = forall f. (Applicative f) => P (->) f a b
 
--- prepare new Context for text at `focus`, no different than with top-level text
--- meanwhile save top-level unconsumed context in second component of `Context`
--- so that ||> has access to it
+-- prepare new Context for text at `focus`
+-- meanwhile add current-level unconsumed to `Context`
 focusing :: Traversal' s Text -> Ptraversal Text a -> Ptraversal s a
-focusing focus go afb s@(_, ctx@(Context unconsumed maybeTop)) =
-  let unconsumed_top = maybe (Just unconsumed) Just maybeTop
-      afb' (a, Context unconsumed _) = afb (a, Context unconsumed unconsumed_top)
-      afbsft = _1 . focus . text . go
-  in afbsft afb' s
+focusing focus inside afb s@(_, ctx@(Context unconsumed above lvl)) =
+  let outside_afbsft = _1 . focus . textAtLevel (lvl+1) (unconsumed:above) . inside
+  in outside_afbsft afb s
+
+textAtLevel :: Int -> [Text] -> Iso' Text (Text, Context)
+textAtLevel lvl unconsumeds = iso (\txt -> (txt, Context "" unconsumeds lvl)) (\(txt, Context rest _ _) -> txt <> rest)
 
 text :: Iso' Text (Text, Context)
-text = iso (\txt -> (txt, Context "" Nothing)) (\(txt, Context rest _) -> txt <> rest)
+text = textAtLevel 0 []
 
 many' :: Ptraversal Text a -> Ptraversal Text a
 many' p = failing (some' p) ignored
@@ -62,14 +61,18 @@ choice' [] = ignored
 (||>?) = andThen False
 
 andThen :: Bool -> Ptraversal a x -> Ptraversal Text y -> Ptraversal a (Either x y)
-andThen rightMustSucceed afbsft afbsft' afb'' s =
+andThen rightMustSucceed afbsft afbsft' afb'' s@(_, Context _ _ youAreHere) =
   let Pair constt ft = afbsft aConstfb s
   in case getConst constt of
-       Last (Just unconsumed) ->
-         let Pair constt' ft' = afbsft' aConstfb' (unconsumed, Context "" Nothing)
+       Last (Just (unconsumed_bottom, above)) ->
+         let unconsumed = fromMaybe unconsumed_bottom $ preview (element (Prelude.length above - youAreHere - 1)) above
+             Pair constt' ft' = afbsft' aConstfb' (unconsumed, Context "" [] youAreHere)
          in case getConst constt' of
            Any True ->
-             let merge (a, Context rebuilt _) (txt, Context ctx _) = (a, Context (actuallyConsumed rebuilt <> txt <> ctx) Nothing)
+             let merge (a, Context rebuilt parent lvl_left) (txt, Context ctx parent' lvl_right) =
+                   (a, Context (actuallyConsumed rebuilt <> txt <> ctx)
+                               (if (lvl_left > lvl_right) then parent else parent')
+                               (max lvl_left lvl_right))
                  actuallyConsumed rebuilt | rebuilt == "" = unconsumed
                  actuallyConsumed rebuilt | otherwise =
                    fromMaybe (error . unpack $ "unconsumed was consumed: \"" <> unconsumed <> "\" / \"" <> rebuilt <> "\"") $
@@ -78,7 +81,7 @@ andThen rightMustSucceed afbsft afbsft' afb'' s =
            Any False -> if rightMustSucceed then pure s else ft
        Last Nothing -> pure s
 
-  where aConstfb  (a,ctx@(Context unconsumed top)) = onlyIfLeft a ctx <$> Pair (Const (Last (Just (fromMaybe unconsumed top)))) (afb'' (Left a, ctx))
+  where aConstfb  (a,ctx@(Context unconsumed above _)) = onlyIfLeft a ctx <$> Pair (Const (Last (Just (unconsumed, above)))) (afb'' (Left a, ctx))
         aConstfb' (a,ctx) = onlyIfRight a ctx <$> Pair (Const (Any True)) (afb'' (Right a, ctx))
 
 onlyIfRight _ _ (Right b, ctx') = (b, ctx')
@@ -88,10 +91,10 @@ onlyIfLeft _ _ (Left b, ctx') = (b, ctx')
 onlyIfLeft a ctx (Right _, _) = (a, ctx)
 
 parseInContext :: Parser a -> (Text, Context) -> Maybe (a, Context)
-parseInContext p (input, (Context after top)) = eitherToMaybe $
+parseInContext p (input, (Context after above lvl)) = eitherToMaybe $
   parse (contextualise <$> p <*> getInput) "" input
   where
-    contextualise parsed unconsumed = (parsed, Context (unconsumed <> after) top)
+    contextualise parsed unconsumed = (parsed, Context (unconsumed <> after) above lvl)
     eitherToMaybe e = case e of
             Left _ -> Nothing
             Right x -> Just x

--- a/src/LazyParseTransforms.hs
+++ b/src/LazyParseTransforms.hs
@@ -53,7 +53,7 @@ andThen :: Bool -> Ptraversal a x -> Ptraversal Text y -> Ptraversal a (Either x
 andThen rightMustSucceed afbsft afbsft' afb'' s =
   let Pair constt ft = afbsft aConstfb s
   in case getLast (getConst constt) of
-       Just (_, Context unconsumed) ->
+       Just (Context unconsumed) ->
          let Pair constt' ft' = afbsft' aConstfb' (unconsumed, Context "")
          in case getConst constt' of
            Any True ->
@@ -66,7 +66,7 @@ andThen rightMustSucceed afbsft afbsft' afb'' s =
            Any False -> if rightMustSucceed then pure s else ft
        Nothing -> pure s
 
-  where aConstfb  (a,ctx) = onlyIfLeft a ctx <$> Pair (Const (Last (Just (a,ctx)))) (afb'' (Left a, ctx))
+  where aConstfb  (a,ctx) = onlyIfLeft a ctx <$> Pair (Const (Last (Just ctx))) (afb'' (Left a, ctx))
         aConstfb' (a,ctx) = onlyIfRight a ctx <$> Pair (Const (Any True)) (afb'' (Right a, ctx))
 
 onlyIfRight _ _ (Right b, ctx') = (b, ctx')

--- a/src/LazyParseTransforms.hs
+++ b/src/LazyParseTransforms.hs
@@ -22,6 +22,9 @@ type P p f a b = Optic' p f (a, Context) (b, Context)
 type Pprism a b = forall p f. (Choice p, Applicative f) => P p f a b
 type Ptraversal a b = forall f. (Applicative f) => P (->) f a b
 
+-- prepare new Context for text at `focus`, no different than with top-level text
+-- meanwhile save top-level unconsumed context in second component of `Context`
+-- so that ||> has access to it
 focusing :: Traversal' s Text -> Ptraversal Text a -> Ptraversal s a
 focusing focus go afb s@(_, ctx@(Context unconsumed maybeTop)) =
   let unconsumed_top = maybe (Just unconsumed) Just maybeTop

--- a/src/LazyParseTransforms.hs
+++ b/src/LazyParseTransforms.hs
@@ -61,12 +61,12 @@ choice' [] = ignored
 (||>?) = andThen False
 
 andThen :: Bool -> Ptraversal a x -> Ptraversal Text y -> Ptraversal a (Either x y)
-andThen rightMustSucceed afbsft afbsft' afb'' s@(_, Context _ _ youAreHere) =
+andThen rightMustSucceed afbsft afbsft' afb'' s@(_, Context _ above youAreHere) =
   let Pair constt ft = afbsft aConstfb s
   in case getConst constt of
-       Last (Just (unconsumed_bottom, above)) ->
-         let unconsumed = fromMaybe unconsumed_bottom $ preview (element (Prelude.length above - youAreHere - 1)) above
-             Pair constt' ft' = afbsft' aConstfb' (unconsumed, Context "" [] youAreHere)
+       Last (Just (unconsumed_bottom, above_bottom)) ->
+         let unconsumed = fromMaybe unconsumed_bottom $ preview (element (Prelude.length above_bottom - youAreHere - 1)) above_bottom
+             Pair constt' ft' = afbsft' aConstfb' (unconsumed, Context "" above youAreHere)
          in case getConst constt' of
            Any True ->
              let merge (a, Context rebuilt parent lvl_left) (txt, Context ctx parent' lvl_right) =

--- a/src/MarkdownLazy.hs
+++ b/src/MarkdownLazy.hs
@@ -24,19 +24,19 @@ i :: Pprism Text Italic
 i = prism' build match
   where
     match = parseInContext $ Italic . pack <$> withinMany (char '*') (noneOf (['*']))
-    build (Italic txt, Context after) = ("*" <> txt <> "*", Context after)
+    build (Italic txt, ctx) = ("*" <> txt <> "*", ctx)
 
 noti :: Pprism Text Text
 noti = prism' build match
   where
     match = parseInContext $ pack <$> many1 (noneOf (['*']))
-    build (txt, Context after) = (txt, Context after)
+    build (txt, ctx) = (txt, ctx)
 
 h :: Int ->  Pprism Text Header
 h n = prism' build match
   where
     match = parseInContext $ Header n . pack <$> between (string (hashes n) *> char ' ') endOfLine (many1 (noneOf ['\n']))
-    build (Header k txt, Context after) = (pack (hashes k) <> " " <> txt <> "\n" , Context after)
+    build (Header k txt, ctx) = (pack (hashes k) <> " " <> txt <> "\n" , ctx)
 
     hashes k = Prelude.take k (Prelude.repeat '#')
 
@@ -54,7 +54,7 @@ notheader :: Pprism Text Text
 notheader = prism' build match
   where
     match = parseInContext $ pack <$> many1 (noneOf (['#']))
-    build (txt, Context after) = (txt, Context after)
+    build (txt, ctx) = (txt, ctx)
 
 allTheHeaders :: Ptraversal Text (Either Header Text)
 allTheHeaders = many' (headers <||> notheader)

--- a/src/MarkdownLazy.hs
+++ b/src/MarkdownLazy.hs
@@ -26,12 +26,6 @@ i = prism' build match
     match = parseInContext $ Italic . pack <$> withinMany (char '*') (noneOf (['*']))
     build (Italic txt, ctx) = ("*" <> txt <> "*", ctx)
 
-noti :: Pprism Text Text
-noti = prism' build match
-  where
-    match = parseInContext $ pack <$> many1 (noneOf (['*']))
-    build (txt, ctx) = (txt, ctx)
-
 h :: Int ->  Pprism Text Header
 h n = prism' build match
   where
@@ -50,14 +44,13 @@ headers = choice' [
   , ChoiceTraversal (h 6)
   ]
 
-notheader :: Pprism Text Text
-notheader = prism' build match
+skip :: [Char] -> Pprism Text Text
+skip toSkip = prism' id match
   where
-    match = parseInContext $ pack <$> many1 (noneOf (['#']))
-    build (txt, ctx) = (txt, ctx)
+    match = parseInContext $ pack <$> many1 (noneOf toSkip)
 
 allTheHeaders :: Ptraversal Text (Either Header Text)
-allTheHeaders = many' (headers <||> notheader)
+allTheHeaders = many' (headers <||> skip "#")
 
 makeLenses ''Italic
 makeLenses ''Header

--- a/src/MarkdownLazy.hs
+++ b/src/MarkdownLazy.hs
@@ -15,6 +15,7 @@ import Control.Lens (prism')
 import Control.Lens.TH
 
 newtype Italic = Italic { _unItalic :: Text } deriving Show
+newtype Strikethrough = Strikethrough { _unStrikethrough :: Text } deriving Show
 data Header = Header {
   _level :: Int,
   _content :: Text
@@ -25,6 +26,12 @@ i = prism' build match
   where
     match = parseInContext $ Italic . pack <$> withinMany (char '*') (noneOf (['*']))
     build (Italic txt, ctx) = ("*" <> txt <> "*", ctx)
+
+strikethrough :: Pprism Text Strikethrough
+strikethrough = prism' build match
+  where
+    match = parseInContext $ Strikethrough . pack <$> withinMany (string "~~") (noneOf (['~']))
+    build (Strikethrough txt, ctx) = ("~~" <> txt <> "~~", ctx)
 
 h :: Int ->  Pprism Text Header
 h n = prism' build match
@@ -54,5 +61,7 @@ allTheHeaders = many' (headers <||> skip "#")
 
 makeLenses ''Italic
 makeLenses ''Header
+makeLenses ''Strikethrough
 makePrisms ''Header
 makePrisms ''Italic
+makePrisms ''Strikethrough

--- a/tests/MarkdownLazyTest.hs
+++ b/tests/MarkdownLazyTest.hs
@@ -95,6 +95,15 @@ spec_markdown_lazy = do
          "# ~~*i* s ~~ h\n unconsumed" `shouldBe`
          "# ~~*_* s ~~ h\n unconsumed"
 
+     it "focusing inside ||> inside focusing" $ do
+       flip set "_" (text . (h 1 . focusing content ((strikethrough . focusing unStrikethrough i) ||> i)) . _1 . _Left . unItalic )
+         "# ~~*i* s ~~*i2* h\n unconsumed" `shouldBe`
+         "# ~~*_* s ~~*i2* h\n unconsumed"
+
+       flip set "_" (text . (h 1 . focusing content ((strikethrough . focusing unStrikethrough i) ||> i)) . _1 . _Right . unItalic )
+         "# ~~*i* s ~~*i2* h\n unconsumed" `shouldBe`
+         "# ~~*i* s ~~*_* h\n unconsumed"
+
      it "||> inside focusing" $ do
        flip set "_" (text . (h 1 . focusing content (i ||> i)) . _1 . _Right . unItalic)
          "# *i**i2* h\n*i3*" `shouldBe`

--- a/tests/MarkdownLazyTest.hs
+++ b/tests/MarkdownLazyTest.hs
@@ -86,6 +86,11 @@ spec_markdown_lazy = do
          "# *i inside* not i\n*i outside*" `shouldBe`
          "# *_* not i\n*i outside*"
 
+     it "focusing twice inside ||>" $ do
+       flip set "_" (text . ((h 1 . focusing content . strikethrough . focusing unStrikethrough . i) ||> skip "") . _1 . _Left . unItalic)
+         "# ~~*i* s ~~ h\n unconsumed" `shouldBe`
+         "# ~~*_* s ~~ h\n unconsumed"
+
      it "focusing after ||>" $ do
        flip set "_" (text . (h 1 ||> i) . focusing (_Left . content) . i . _1 . unItalic)
          "# *i inside* not i\n*i outside*" `shouldBe`

--- a/tests/MarkdownLazyTest.hs
+++ b/tests/MarkdownLazyTest.hs
@@ -96,13 +96,17 @@ spec_markdown_lazy = do
          "# ~~*_* s ~~ h\n unconsumed"
 
      it "focusing inside ||> inside focusing" $ do
-       flip set "_" (text . (h 1 . focusing content ((strikethrough . focusing unStrikethrough i) ||> i)) . _1 . _Left . unItalic )
-         "# ~~*i* s ~~*i2* h\n unconsumed" `shouldBe`
-         "# ~~*_* s ~~*i2* h\n unconsumed"
+       flip set "_" (text . ((h 1 . focusing content ((strikethrough . focusing unStrikethrough i) ||> i)) ||> i) . _1._Left._Left.unItalic)
+         "# ~~*i* s ~~*i2* h\n*i3*" `shouldBe`
+         "# ~~*_* s ~~*i2* h\n*i3*"
 
-       flip set "_" (text . (h 1 . focusing content ((strikethrough . focusing unStrikethrough i) ||> i)) . _1 . _Right . unItalic )
-         "# ~~*i* s ~~*i2* h\n unconsumed" `shouldBe`
-         "# ~~*i* s ~~*_* h\n unconsumed"
+       flip set "_" (text . ((h 1 . focusing content ((strikethrough . focusing unStrikethrough i) ||> i)) ||> i) . _1._Left._Right.unItalic)
+         "# ~~*i* s ~~*i2* h\n*i3*" `shouldBe`
+         "# ~~*i* s ~~*_* h\n*i3*"
+
+       flip set "_" (text . ((h 1 . focusing content ((strikethrough . focusing unStrikethrough i) ||> i)) ||> i) . _1._Right.unItalic)
+         "# ~~*i* s ~~*i2* h\n*i3*" `shouldBe`
+         "# ~~*i* s ~~*i2* h\n*_*"
 
      it "||> inside focusing" $ do
        flip set "_" (text . (h 1 . focusing content (i ||> i)) . _1 . _Right . unItalic)

--- a/tests/MarkdownLazyTest.hs
+++ b/tests/MarkdownLazyTest.hs
@@ -77,27 +77,36 @@ spec_markdown_lazy = do
 
    describe "focusing" $ do
      it "focusing" $ do
-       flip set "_" (text . h 1 . focusing content . i . _1 . unItalic)
+       flip set "_" (text . h 1 . focusing content i . _1 . unItalic)
          "# *i* not i\n not h" `shouldBe`
          "# *_* not i\n not h"
 
      it "focusing inside ||>" $ do
-       flip set "_" (text . ((h 1 . focusing content . i) ||> i) . _1 . _Left . unItalic)
-         "# *i inside* not i\n*i outside*" `shouldBe`
-         "# *_* not i\n*i outside*"
+       flip set "_" (text . ((h 1 . focusing content i) ||> i) . _1 . _Left . unItalic)
+         "# *i* not i\n*i*" `shouldBe`
+         "# *_* not i\n*i*"
+
+       flip set "_" (text . ((h 1 . focusing content i) ||> i) . _1 . _Right . unItalic)
+         "# *i* not i\n*i*" `shouldBe`
+         "# *i* not i\n*_*"
 
      it "focusing twice inside ||>" $ do
-       flip set "_" (text . ((h 1 . focusing content . strikethrough . focusing unStrikethrough . i) ||> skip "") . _1 . _Left . unItalic)
+       flip set "_" (text . ((h 1 . focusing content (strikethrough . focusing unStrikethrough i)) ||> skip "") . _1 . _Left . unItalic)
          "# ~~*i* s ~~ h\n unconsumed" `shouldBe`
          "# ~~*_* s ~~ h\n unconsumed"
 
+     it "||> inside focusing" $ do
+       flip set "_" (text . (h 1 . focusing content (i ||> i)) . _1 . _Right . unItalic)
+         "# *i**i2* h\n*i3*" `shouldBe`
+         "# *i**_* h\n*i3*"
+
      it "focusing after ||>" $ do
-       flip set "_" (text . (h 1 ||> i) . focusing (_Left . content) . i . _1 . unItalic)
+       flip set "_" (text . (h 1 ||> i) . focusing (_Left . content) i . _1 . unItalic)
          "# *i inside* not i\n*i outside*" `shouldBe`
          "# *_* not i\n*i outside*"
 
      it "focusing after many" $ do
-       flip set "_" (text . many' (h 1) . focusing content . i . _1 . unItalic)
+       flip set "_" (text . many' (h 1) . focusing content i . _1 . unItalic)
          "# *i* not i\n# *i2* not i2\n# no i\n *i* not i" `shouldBe`
          "# *_* not i\n# *_* not i2\n# no i\n *i* not i"
 

--- a/tests/MarkdownLazyTest.hs
+++ b/tests/MarkdownLazyTest.hs
@@ -81,6 +81,11 @@ spec_markdown_lazy = do
          "# *i* not i\n not h" `shouldBe`
          "# *_* not i\n not h"
 
+     it "focusing inside ||>" $ do
+       flip set "_" (text . ((h 1 . focusing content . i) ||> i) . _1 . _Left . unItalic)
+         "# *i inside* not i\n*i outside*" `shouldBe`
+         "# *_* not i\n*i outside*"
+
      it "focusing after ||>" $ do
        flip set "_" (text . (h 1 ||> i) . focusing (_Left . content) . i . _1 . unItalic)
          "# *i inside* not i\n*i outside*" `shouldBe`


### PR DESCRIPTION
properly define `focusing` so that it works inside `||>`

`left ||> right` require running `left` to get unconsumed input to pass to `right`
but if `left` has undergone `focusing` it would get the "local" "focused" unconsumed instead

solution: `focusing` saves the parent unconsumed context in a second argument to `Context`