### PR TITLE
unindent bullets into subheader

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -31,7 +31,6 @@ dependencies:
 - parsec
 - foldl
 - vector
-- deriving-compat
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -31,6 +31,8 @@ dependencies:
 - parsec
 - foldl
 - vector
+- data-fix
+- deriving-compat
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -31,7 +31,6 @@ dependencies:
 - parsec
 - foldl
 - vector
-- data-fix
 - deriving-compat
 
 library:

--- a/src/MarkdownLazy.hs
+++ b/src/MarkdownLazy.hs
@@ -16,6 +16,7 @@ import Control.Lens.TH
 
 newtype Italic = Italic { _unItalic :: Text } deriving Show
 newtype Strikethrough = Strikethrough { _unStrikethrough :: Text } deriving Show
+data Bullet = Bullet Int Text deriving Show
 data Header = Header {
   _level :: Int,
   _content :: Text
@@ -40,6 +41,16 @@ h n = prism' build match
     build (Header k txt, ctx) = (pack (hashes k) <> " " <> txt <> "\n" , ctx)
 
     hashes k = Prelude.take k (Prelude.repeat '#')
+
+bullet :: Pprism Text Bullet
+bullet = prism' build match
+  where
+    match = parseInContext $ Bullet <$> (spaces <* string "- ") <*> (pack <$> many1 (noneOf "\n"))
+
+    build (Bullet level txt, ctx) = (T.replicate level "  " <> "-" <> txt <> "\n", ctx)
+
+    spaces :: Parser Int
+    spaces =  Prelude.length <$> many (string "  ")
 
 headers :: Ptraversal Text Header
 headers = choice' [

--- a/src/MarkdownLazy.hs
+++ b/src/MarkdownLazy.hs
@@ -109,9 +109,9 @@ unindentBulletIntoSubheader :: Text -> Text -> Text
 unindentBulletIntoSubheader style = execState $
   zoom (text . many' htc . _1 . _Fix. _HeaderTitleContent) $ do
     (headerLevel, _, _) <- get
-    zoom (_3 . _Fix . _Plain) $ do
+    zoom (_3 . _Fix . _Plain . text . many' bullet . _1) $ do
        let f (Fix (B _ lvl content)) = Fix (if lvl==0 then (H (headerLevel+1) content) else B style (lvl-1) content)
-       modify $ over (text . many' bullet . _1) f
+       modify f
 
 
 headers :: Ptraversal Text Header

--- a/tests/MarkdownLazyTest.hs
+++ b/tests/MarkdownLazyTest.hs
@@ -7,6 +7,7 @@ import Test.Tasty.Hspec
 import MarkdownLazy
 import LazyParseTransforms
 import Control.Lens
+import Data.Fix
 
 spec_markdown_lazy :: Spec
 spec_markdown_lazy = do
@@ -143,3 +144,9 @@ spec_markdown_lazy = do
        flip set "_" (text . many' (i <||> h 1) . _1 . _Right . content)
          "*i*# h1\n" `shouldBe`
          "*i*# _\n"
+
+   describe "can unnest types of parsed with Fix" $ do
+     it "unindenting level zero bullet makes it not bullet" $ do
+       flip over (\(Fix (B lvl content@(Fix (Plain txt)))) -> if lvl > 0 then Fix (B (lvl-1) content) else Fix (Plain (txt <> "\n"))) (text . many' bullet . _1)
+         "- b 1\n  - b 2\n" `shouldBe`
+         "b 1\n- b 2\n"

--- a/tests/MarkdownLazyTest.hs
+++ b/tests/MarkdownLazyTest.hs
@@ -7,7 +7,6 @@ import Test.Tasty.Hspec
 import MarkdownLazy
 import LazyParseTransforms
 import Control.Lens
-import Data.Fix
 
 spec_markdown_lazy :: Spec
 spec_markdown_lazy = do
@@ -145,8 +144,8 @@ spec_markdown_lazy = do
          "*i*# h1\n" `shouldBe`
          "*i*# _\n"
 
-   describe "can unnest types of parsed with Fix" $ do
+   describe "can unnest types of parsed with sum types" $ do
      it "unindenting level zero bullet makes it not bullet" $ do
-       flip over (\(Fix (B lvl content@(Fix (Plain txt)))) -> if lvl > 0 then Fix (B (lvl-1) content) else Fix (Plain (txt <> "\n"))) (text . many' bullet . _1)
+       flip over (\(Bullet style lvl content@txt) -> if lvl > 0 then (Bullet style (lvl-1) content) else Plain (txt <> "\n")) (text . many' bullet . _1)
          "- b 1\n  - b 2\n" `shouldBe`
          "b 1\n- b 2\n"

--- a/unindent-headers-bullets/Main.hs
+++ b/unindent-headers-bullets/Main.hs
@@ -8,7 +8,6 @@ import Control.Lens
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
 import qualified Control.Foldl as F
-import Data.Fix
 
 import Turtle as T (stdin, lineToText, inproc, die, empty, fold)
 

--- a/unindent-headers-bullets/Main.hs
+++ b/unindent-headers-bullets/Main.hs
@@ -14,8 +14,5 @@ import Turtle as T (stdin, lineToText, inproc, die, empty, fold)
 
 getText = T.fold stdin (F.foldMap (\l -> lineToText l <> "\n") id)
 
-unindentHeaders = flip over (\level -> max (level-1) 1)  (text . allTheHeaders . _1 . _Left . level)
-unindentBullets = flip over (\(Fix (B lvl content@(Fix (Plain txt)))) -> if lvl > 0 then Fix (B (lvl-1) content) else Fix (Plain (txt <> "\n"))) (text . many' bullet . _1)
-
 main :: IO ()
-main = TIO.putStr . unindentBullets . unindentHeaders =<< getText
+main = TIO.putStr . unindentBulletIntoSubheader =<< getText

--- a/unindent-headers-bullets/Main.hs
+++ b/unindent-headers-bullets/Main.hs
@@ -15,4 +15,4 @@ import Turtle as T (stdin, lineToText, inproc, die, empty, fold)
 getText = T.fold stdin (F.foldMap (\l -> lineToText l <> "\n") id)
 
 main :: IO ()
-main = TIO.putStr . unindentBulletIntoSubheader =<< getText
+main = TIO.putStr . unindentBulletIntoSubheader "\t" =<< getText

--- a/unindent-headers-bullets/Main.hs
+++ b/unindent-headers-bullets/Main.hs
@@ -8,12 +8,14 @@ import Control.Lens
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
 import qualified Control.Foldl as F
+import Data.Fix
 
 import Turtle as T (stdin, lineToText, inproc, die, empty, fold)
 
 getText = T.fold stdin (F.foldMap (\l -> lineToText l <> "\n") id)
 
 unindentHeaders = flip over (\level -> max (level-1) 1)  (text . allTheHeaders . _1 . _Left . level)
+unindentBullets = flip over (\(Fix (B lvl content@(Fix (Plain txt)))) -> if lvl > 0 then Fix (B (lvl-1) content) else Fix (Plain (txt <> "\n"))) (text . many' bullet . _1)
 
 main :: IO ()
-main = TIO.putStr . unindentHeaders =<< getText
+main = TIO.putStr . unindentBullets . unindentHeaders =<< getText


### PR DESCRIPTION
if we want to change a `Bullet Int Text` to a `Text` (say, if we want to unindent, but then for a top level bullet we want to make it not a bullet), we need to put them under the same type:

```haskell
data Cases a =
    Bullet Int a
  | Italic a
  | Header Int a
  -- etc.
  | Plain Text
  deriving (Show, Functor)

type Markdown = Fix Cases
```

~~we then use `Fix` to be polymorphic over nesting depth (say, header inside italic has same as the plain text inside that italic)~~

can use sum types instead of `Fix`
issue: violates `Prism` review-preview law