### PR TITLE
No trim suffix

### DIFF
--- a/src/LazyParseTransforms.hs
+++ b/src/LazyParseTransforms.hs
@@ -97,6 +97,12 @@ onlyIfRight a ctx (Left _, _) = (a, ctx)
 onlyIfLeft _ _ (Left b, ctx') = (b, ctx')
 onlyIfLeft a ctx (Right _, _) = (a, ctx)
 
+pprism :: Parser a -> (a -> Text) -> Pprism Text a
+pprism parse render = prism' build match
+  where
+    match = parseInContext parse
+    build (a, ctx) = (render a, ctx)
+
 parseInContext :: Parser a -> (Text, Context) -> Maybe (a, Context)
 parseInContext p (input, (Context after above lvl)) = eitherToMaybe $
   parse (contextualise <$> p <*> getInput) "" input

--- a/src/LazyParseTransforms.hs
+++ b/src/LazyParseTransforms.hs
@@ -70,12 +70,15 @@ choice' [] = ignored
 -- third crux is removing from unconsumed of left, the part which was also unconsumed by right
 andThen :: Bool -> Ptraversal a x -> Ptraversal Text y -> Ptraversal a (Either x y)
 andThen rightMustSucceed afbsft afbsft' afb'' s@(_, Context _ above lvl_s) =
+  -- run left
   let Pair constt ft = afbsft aConstfb s
   in case getConst constt of
        Last (Just (unconsumed, isFocused)) ->
+         -- run right, on unconsumed from left
          let Pair constt' ft' = afbsft' aConstfb' (unconsumed, Context "" above lvl_s)
          in case getConst constt' of
            Any True ->
+             -- merge results of both left/right
              let merge (a, Context ctx _ _) (txt, Context ctx' _ _) =
                    -- if focused, then everything consumed will be rebuilt into 'a',
                    --   so discard 'ctx' which consists entirely of unconsumed

--- a/src/LazyParseTransforms.hs
+++ b/src/LazyParseTransforms.hs
@@ -92,8 +92,8 @@ andThen rightMustSucceed afbsft afbsft' afb'' s@(_, Context _ above lvl_s) =
 
   where aConstfb  (a,ctx@(Context unconsumed abv lvl)) =
           let isFocused = lvl > 0
-              -- discard 'unconsumed' if focused, since it is now the responsibility of afbsft'
-              -- otherwise 'unconsumed' is local to afbst, so will be rebuilt into ancestors
+              -- if not focused, discard 'unconsumed', since it is now the responsibility of afbsft'
+              -- if focused, 'unconsumed' is local to afbst, so will be rebuilt into ancestors
               ctx' = Context (if isFocused then unconsumed else "") abv lvl
               unconsumed_top = fromMaybe unconsumed (abv !? lvl_s)
           in onlyIfLeft a ctx' <$> Pair

--- a/src/MarkdownLazy.hs
+++ b/src/MarkdownLazy.hs
@@ -22,20 +22,20 @@ data Header = Header {
   _content :: Text
 } deriving Show
 
-i :: Pprism Text Italic
-i = pprism parse render
+i :: PPrism Text Italic
+i = pPrism parse render
   where
     parse = Italic . pack <$> withinMany (char '*') (noneOf (['*']))
     render (Italic txt) = ("*" <> txt <> "*")
 
-strikethrough :: Pprism Text Strikethrough
-strikethrough = pprism parse render
+strikethrough :: PPrism Text Strikethrough
+strikethrough = pPrism parse render
   where
     parse = Strikethrough . pack <$> withinMany (string "~~") (noneOf (['~']))
     render (Strikethrough txt) = ("~~" <> txt <> "~~")
 
-h :: Int ->  Pprism Text Header
-h n = pprism parse render
+h :: Int ->  PPrism Text Header
+h n = pPrism parse render
   where
     parse = Header n . pack <$> between (string (hashes n) *> char ' ') endOfLine (many1 (noneOf ['\n']))
     render (Header k txt) = pack (hashes k) <> " " <> txt <> "\n"
@@ -54,8 +54,8 @@ buildCases (Plain txt) = txt
 buildCases (Bullet style lvl txt) = T.replicate lvl style <> "- " <> txt <> "\n"
 buildCases (HeaderTitleContent lvl title content) = T.replicate lvl "#" <> " " <> title <> "\n" <> content
 
-bullet :: Pprism Text Cases
-bullet = pprism parse render
+bullet :: PPrism Text Cases
+bullet = pPrism parse render
   where
     parse = uncurry Bullet <$> indentation <*> content
 
@@ -71,8 +71,8 @@ bullet = pprism parse render
 
     noIndent = ("", 0) <$ string ""
 
-htc :: Pprism Text Cases
-htc = pprism parse render
+htc :: PPrism Text Cases
+htc = pPrism parse render
   where
     parse = (HeaderTitleContent <$> (numHashes <* char ' '))
       <*> title
@@ -92,7 +92,7 @@ unindentBulletIntoSubheader style = execState $
        modify f
 
 
-headers :: Ptraversal Text Header
+headers :: PTraversal Text Header
 headers = choice' [
     ChoiceTraversal (h 1)
   , ChoiceTraversal (h 2)
@@ -102,12 +102,12 @@ headers = choice' [
   , ChoiceTraversal (h 6)
   ]
 
-skip :: [Char] -> Pprism Text Text
-skip toSkip = pprism parse id
+skip :: [Char] -> PPrism Text Text
+skip toSkip = pPrism parse id
   where
     parse = pack <$> many1 (noneOf toSkip)
 
-allTheHeaders :: Ptraversal Text (Either Header Text)
+allTheHeaders :: PTraversal Text (Either Header Text)
 allTheHeaders = many' (headers <||> skip "#")
 
 makeLenses ''Italic


### PR DESCRIPTION
in `andThen first second`
`first` will have superfluous unconsumed context, corresponding to what even `second` did not consume
instead of running `first` and then trimming, just discard in the first place