### PR TITLE
Parse lone '*' and '=' as literal text

### DIFF
--- a/src/MarkdownParse.hs
+++ b/src/MarkdownParse.hs
@@ -133,7 +133,13 @@ header n = Header n <$>
 
 markdownItemsBasic = choice . fmap try $ [
     highlight, bold, italic, link, tag, BasicInline <$> base (oneOf "*=" <||> string "[[")
+  , literalSpecial
   ]
+
+-- A lone '*' or '=' that forms no valid marker (highlight/bold/italic) would
+-- otherwise stall the parser, since `unmarked` refuses to start on its own
+-- stop-chars. Consume it as literal text.
+literalSpecial = BasicInline . Unmarked . (:[]) <$> oneOf "*="
 
 base endWith = choice [ inlineMath, unmarked (char '$' <||> endWith) ]
 

--- a/tests/MarkdownParseTest.hs
+++ b/tests/MarkdownParseTest.hs
@@ -282,6 +282,28 @@ test_complex =
               ])
         ]
     ]
+    , testGroup "literal specials" [
+        testCase "lone equals in prose" $
+          parse (markdown eof) "" "foo = bar" @?= Right (Markdown . fmap Basic $ [
+              BasicInline . Unmarked $ "foo "
+            , BasicInline . Unmarked $ "="
+            , BasicInline . Unmarked $ " bar"
+            ])
+      , testCase "lone star in prose" $
+          parse (markdown eof) "" "a * b" @?= Right (Markdown . fmap Basic $ [
+              BasicInline . Unmarked $ "a "
+            , BasicInline . Unmarked $ "*"
+            , BasicInline . Unmarked $ " b"
+            ])
+      , testCase "equals after math with following italic" $
+          parse (markdown eof) "" "$x$ = *y*" @?= Right (Markdown . fmap Basic $ [
+              BasicInline . InlineMath $ "x"
+            , BasicInline . Unmarked $ " "
+            , BasicInline . Unmarked $ "="
+            , BasicInline . Unmarked $ " "
+            , Italic [Unmarked "y"]
+            ])
+      ]
     , testGroup "everything" [
         testCase "unmarked" $
           parse everything "" "abc" @?= Right (Content [ Markdown [ Basic (BasicInline (Unmarked "abc")) ] ])


### PR DESCRIPTION
## Problem

Markdown containing a stray `=` in prose (e.g. `$\{e_\xi\}$ = respecting`) fails to parse entirely. Parsec reports a misleading `expected table row` error, which is just the last alternative tried after the real parse dead-ends.

## Root cause

`unmarked` deliberately stops at `*`, `=`, `$`, `[[` so markers like `==` (highlight), `**`/`*…*` (bold/italic), and `[[…]]` (link) can be recognised. But a **lone** `=` or `*` that forms no valid marker can't be consumed by anything: `highlight` needs a second `=`, `italic` needs a closing `*`, and `unmarked` refuses to *start* on one of its own stop-chars. The parser gets stuck. (Single `[` was already fine since it needs `[[` to stop.)

## Fix

Add a `literalSpecial` last-resort fallback in `markdownItemsBasic` that consumes a single stuck `*` or `=` as `Unmarked` text. It runs only after `highlight`/`bold`/`italic`/`link` have been tried, so real markers parse exactly as before.

## Tests

Added 3 cases (lone `=`, lone `*`, `=` between math and italic). Full suite: 68 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
